### PR TITLE
Add goant

### DIFF
--- a/info.json
+++ b/info.json
@@ -301,5 +301,11 @@
     "description": "A ES5 JavaScript engine written in Rust",
     "url": "https://github.com/ahaoboy/es5",
     "lang": "rust"
+  },
+  {
+    "name": "goant",
+    "description": "A JavaScript engine in pure Go: no cgo, one static binary, a baseline JIT for amd64/arm64, 99.4% test262 (53,247/53,573)",
+    "url": "https://github.com/robomotionio/goant",
+    "lang": "go"
   }
 ]

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -121,7 +121,10 @@ async function getVersion(cmd: string) {
     const text = await execCmd(`${cmd} -h`);
     return text.match(/version (\d+\.\d+\.\d+)/)?.[1].trim();
   }
-  if (cmd === "tjs" || cmd === "lo" || cmd === "paserati" || cmd === "node") {
+  if (
+    cmd === "tjs" || cmd === "lo" || cmd === "paserati" || cmd === "node" ||
+    cmd === "goant"
+  ) {
     const text = await execCmd(`${cmd} --version`);
     return text.match(/v([\d.]+(?:-[a-zA-Z0-9]+)?)/)?.[1].trim();
   }


### PR DESCRIPTION
[goant](https://github.com/robomotionio/goant) is a JavaScript engine written in
pure Go. No cgo, one static binary, and it cross-compiles wherever Go does. It
passes **99.4% of test262** with nothing excluded (53,247 / 53,573) and has a
baseline JIT for amd64 and arm64. It runs customer JavaScript in production at
[Robomotion](https://www.robomotion.io), an RPA platform.

This PR only touches `info.json` and `scripts/update.ts`, because that is what
you kept when you added ant in #31 -- the install belongs in `js-engine-setup`,
and the README and the platform JSONs are generated by CI.

### What you need to add on your side

One line in `ahaoboy/js-engine-setup`, next to lumen:

```
https://github.com/robomotionio/goant/releases/tag/nightly
```

The rolling `nightly` tag is rebuilt from `main` and is the form you recommended
in #31. There is also a normal release if you prefer a fixed version: the bare
repo URL `https://github.com/robomotionio/goant` resolves to `v0.1.0`, since it
is not a prerelease.

Please also add `goant` to the skip list in `strip.sh`, alongside `goja` and
`paserati`. It is a Go binary, and it already ships stripped (`-ldflags "-s -w"`),
so there is nothing for `strip` to gain.

### Binaries

Six platforms, from a single release. All fetch unauthenticated:

```
goant-x86_64-unknown-linux-gnu.tar.gz    goant-aarch64-unknown-linux-gnu.tar.gz
goant-x86_64-apple-darwin.tar.gz         goant-aarch64-apple-darwin.tar.gz
goant-x86_64-pc-windows-gnu.zip          goant-aarch64-pc-windows-gnu.zip
```

Windows is covered on both architectures.

### Version

`goant --version` prints one line:

```
$ goant --version
goant v0.1.0-7ed32b3
```

That is why this PR adds `goant` to the existing `tjs`/`lo`/`paserati`/`node`
branch rather than writing a new one: the regex there already returns
`0.1.0-7ed32b3`, which your `.replaceAll("-", ".")` renders as `0.1.0.7ed32b3` --
the same shape as lumen. No new parsing code.

### Notes

- Output goes to **stdout**, so no special case is needed like goja's.
- `print` and `console.log` both exist, and `run.js` reassigning
  `var print = console.log` works.
- All nine benchmarks complete, no errors.

I ran `dist/run.js` and your `toJSON` parser against the released binary
locally, and every row parses. My machine is not your CI so the numbers are only
indicative, but for scale: **Score 1117**, with Crypto 2575 and NavierStokes
5848.

The JIT is on by default in the binary, so there is no environment variable to
remember.