### PR TITLE
Add zjs (Zig QuickJS rewrite)

### DIFF
--- a/info.json
+++ b/info.json
@@ -306,5 +306,12 @@
     "description": "A JavaScript engine in pure Go",
     "url": "https://github.com/robomotionio/goant",
     "lang": "go"
+  },
+  {
+    "name": "zjs",
+    "description": "A Zig-native JavaScript engine, source-aligned with QuickJS.",
+    "url": "https://github.com/aneryu/zjs",
+    "install": "https://github.com/aneryu/zjs",
+    "lang": "zig"
   }
 ]

--- a/scripts/update.ts
+++ b/scripts/update.ts
@@ -122,6 +122,9 @@ async function getVersion(cmd: string) {
     const text = await execCmd(`${cmd} -h`);
     return text.match(/version (\d{4}-\d{2}-\d{2})/)?.[1].trim();
   }
+  if (cmd === "zjs") {
+    return (await execCmd(`${cmd} --print-config-signature`)).trim();
+  }
   if (cmd === "qjs-ng") {
     const text = await execCmd(`${cmd} -h`);
     return text.match(/version (\d+\.\d+\.\d+)/)?.[1].trim();


### PR DESCRIPTION
## Summary
- Add **zjs** to `info.json` so it appears in the engine table.
- Teach `scripts/update.ts` to read Version from `zjs --print-config-signature`.

[zjs](https://github.com/aneryu/zjs) is a Zig rewrite of QuickJS. The CLI is `zjs file.js`, same as qjs. Install already works:

```
ei https://github.com/aneryu/zjs
```

Companion setup PR: https://github.com/ahaoboy/js-engine-setup/pull/3

Closes #39

Please also close the accidental empty issue https://github.com/ahaoboy/js-engine-benchmark/issues/38 (`probe`). I cannot close it from this account.

## Test plan
- [ ] `ei https://github.com/aneryu/zjs` installs the linux x86_64 nightly CLI
- [ ] `zjs -e 'print(1+1)'` prints `2`
- [ ] `zjs --print-config-signature` returns a version string for `update.ts`


Made with [Cursor](https://cursor.com)